### PR TITLE
fix: remove posts.json from git tracking and add generation step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate posts data
+        run: |
+          echo "🔄 Regenerating posts.json with latest content..."
+          node scripts/generate-posts-data.js
+          echo "✅ Posts data regenerated successfully!"
+
       - name: Build project
         run: npm run ci:build
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ next-env.d.ts
 # wrangler files
 .wrangler
 .dev.vars*
+
+# generated files
+src/data/posts.json


### PR DESCRIPTION
- Add posts.json to .gitignore (it's a generated file)
- Add posts generation step to deployment workflow
- Remove posts.json from repository tracking